### PR TITLE
fix syntax highlighting and missing curly brace

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,45 +9,52 @@ RZAssert
 
 You define a method on a class, but you want that method to ONLY be called by subclasses. Use `RZASSERT_SUBCLASSES_MUST_OVERRIDE` to throw an exception if the method is called from the class itself:
 
-	@implementation RZSuperclass
-	
-	- (void)aMethodThatShouldBeCalledFromSubclassesOnly
-	{
-		RZASSERT_SUBCLASSES_MUST_OVERRIDE;
-	}
+```objc
+@implementation RZSuperclass
 
-	@end
+- (void)aMethodThatShouldBeCalledFromSubclassesOnly
+{
+    RZASSERT_SUBCLASSES_MUST_OVERRIDE;
+}
+
+@end
+```
 
 You define a switch statement with a case that should never occur. Use `RZASSERT_SHOULD_NEVER_GET_HERE` to throw an exception if your program passes the undesired case to the switch statement:
 
-	typedef NS_ENUM(NSInteger, RZAwesomeMode) {
-		INVAwesomeModeNotSet = 0,
-		INVAwesomeModeIsAwesome
-	};
+```objc
+typedef NS_ENUM(NSInteger, RZAwesomeMode) {
+    INVAwesomeModeNotSet = 0,
+    INVAwesomeModeIsAwesome
+};
 
-	@implementation RZMyClass
+@implementation RZMyClass
 
-	- (void)configureThingsForAwesomeMode:(RZAwesomeMode)awesomeMode
-	{
-		switch ( awesomeMode ) {
-			case INVAwesomeModeNotSet: {
-				RZASSERT_SHOULD_NEVER_GET_HERE;
-				break;
-	  		case INVAwesomeModeIsAwesome: {
-				[self doAwesomeStuff];
-				break;
-			}
-		}
-	}
+- (void)configureThingsForAwesomeMode:(RZAwesomeMode)awesomeMode
+{
+    switch ( awesomeMode ) {
+        case INVAwesomeModeNotSet: {
+            RZASSERT_SHOULD_NEVER_GET_HERE;
+            break;
+        }
+        case INVAwesomeModeIsAwesome: {
+            [self doAwesomeStuff];
+            break;
+        }
+    }
+}
 
-	@end
+@end
+```
 
 You define a method which takes a class instance as one of its arguments, and you want to confirm that the instance conforms to a specific protocol. You use `RZASSERT_CONFORMS_PROTOCOL` to throw an exception if the program passes a nonconformant instance to the method:
 
-	- (void)configureThingsForDictionary:(RZAwesomeViewController *)awesomeViewController
-	{
-		RZASSERT_CONFORMS_PROTOCOL(awesomeViewController, @protocol(RZAwesomeDelegate));
-	}
+```objc
+- (void)configureThingsForDictionary:(RZAwesomeViewController *)awesomeViewController
+{
+    RZASSERT_CONFORMS_PROTOCOL(awesomeViewController, @protocol(RZAwesomeDelegate));
+}
+```
 
 ## Usage
 
@@ -58,7 +65,9 @@ To run the example project, clone the repo, and run `pod install` from the Examp
 RZAssert is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
-    pod RZAssert, '~> 0.1'
+```ruby
+pod RZAssert, '~> 0.1'
+```
 
 ## Author
 


### PR DESCRIPTION
Used code specifiers where appropriate to get syntax highlighting. View the rich diff (button in the top of the diff toolbar) for a better view of the changes.